### PR TITLE
Full refactor pass, with a focus on cleaning up string conversions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,6 @@ oprofile_data/
 /bin/*ReplayLoader
 /bin/PCSX2-linux.sh
 /bin/GSdx*.txt
-/bin/portable.yaml
 /bin/bios
 /bin/dumps
 /bin/help

--- a/common/include/Utilities/PathUtils.h
+++ b/common/include/Utilities/PathUtils.h
@@ -12,14 +12,14 @@ namespace fs = ghc::filesystem;
 namespace Path
 {
 	extern bool IsRelative(const std::string& path);
-	extern s64 GetFileSize(const std::string& path);
+	// Returns -1 if the file does not exist.
+	extern s64 GetFileSize(const fs::path& file);
 
 	extern wxString Normalize(const wxString& srcpath);
 	extern wxString Normalize(const wxDirName& srcpath);
 	extern std::string MakeAbsolute(const std::string& srcpath);
 
-	extern fs::path Combine(fs::path &srcPath, fs::path &srcFile);
-	extern std::string Combine(const std::string& srcPath, const std::string& srcFile);
+	extern fs::path Combine(const fs::path &srcPath, const fs::path &srcFile);
 	extern std::string ReplaceExtension(const wxString& src, const wxString& ext);
 	extern std::string ReplaceFilename(const wxString& src, const wxString& newfilename);
 	extern std::string GetFilename(const std::string& src);
@@ -29,11 +29,10 @@ namespace Path
 	extern fs::path GetExecutableDirectory();
 	extern fs::path isPortable(fs::path p, bool isPortable);
 	extern wxString ToWxString(const fs::path&);
+	extern fs::path FromWxString(const wxString&);
 	extern bool CreateFolder(fs::path path);
 	// Is the folder empty
 	extern bool Empty(std::string);
-	// Does the path exist
-	extern bool DoesExist(std::string path);
 	// Does the path exist
 	extern bool DoesExist(fs::path path);
 } // namespace Path

--- a/common/src/Utilities/PathUtils.cpp
+++ b/common/src/Utilities/PathUtils.cpp
@@ -91,14 +91,12 @@ bool Path::IsRelative(const std::string &path)
 	return fs::path(path).is_relative();
 }
 
-// Returns -1 if the file does not exist.
-s64 Path::GetFileSize(const std::string &path)
+s64 Path::GetFileSize(const fs::path &path)
 {
-    if (!fs::exists(path.c_str()))
+    if (!fs::exists(path))
         return -1;
     return (s64)fs::file_size(path);
 }
-
 
 wxString Path::Normalize(const wxString &src)
 {
@@ -117,20 +115,11 @@ std::string Path::MakeAbsolute(const std::string &src)
     return ghc::filesystem::absolute(src);
 }
 
-// Concatenates two pathnames together, inserting delimiters (backslash on win32)
-// as needed! Assumes the 'dest' is allocated to at least g_MaxPath length.
-//
-fs::path Path::Combine(fs::path &srcPath, fs::path &srcFile)
+fs::path Path::Combine(const fs::path &srcPath, const fs::path &srcFile)
 {
     return (srcPath / srcFile).make_preferred();
 }
 
-std::string Path::Combine(const std::string &srcPath, const std::string &srcFile)
-{
-    fs::path srcP = srcPath;
-    fs::path srcF = srcFile;
-    return (srcP / srcF).make_preferred();
-}
 // Replaces the extension of the file with the one given.
 // This function works for path names as well as file names.
 std::string Path::ReplaceExtension(const wxString &src, const wxString &ext)
@@ -225,11 +214,6 @@ bool Path::CreateFolder(fs::path path)
     return fs::create_directories(path.make_preferred()); // An attempt to create the User mode Dir which already exists
 }
 
-bool Path::DoesExist(std::string path)
-{
-    return fs::exists(fs::path(path).make_preferred());
-}
-
 bool Path::DoesExist(fs::path path)
 {
     try
@@ -248,6 +232,15 @@ wxString Path::ToWxString(const fs::path& path)
 	return wxString(path.wstring());
 #else
 	return wxString(path.string());
+#endif
+}
+
+fs::path Path::FromWxString(const wxString& path)
+{
+#ifdef _WIN32
+	return fs::path(path.ToStdWstring());
+#else
+	return fs::path(path.ToStdString());
 #endif
 }
 

--- a/pcsx2/CDVD/CDVD.cpp
+++ b/pcsx2/CDVD/CDVD.cpp
@@ -102,8 +102,7 @@ static void cdvdGetMechaVer(u8* ver)
 	if (mecfile.IsDir())
 		throw Exception::CannotCreateStream(fname);
 
-
-	if (Path::GetFileSize(fname.ToStdString()) < 4)
+	if (Path::GetFileSize(Path::FromWxString(fname)) < 4)
 	{
 		Console.Warning("MEC File Not Found, creating substitute...");
 
@@ -176,7 +175,7 @@ static void cdvdNVM(u8* buffer, int offset, size_t bytes, bool read)
 	if (nvmfile.IsDir())
 		throw Exception::CannotCreateStream(fname);
 
-	if (Path::GetFileSize(fname.ToStdString()) < 1024)
+	if (Path::GetFileSize(Path::FromWxString(fname)) < 1024)
 	{
 		Console.Warning("NVM File Not Found, creating substitute...");
 
@@ -367,7 +366,7 @@ static MutexRecursive Mutex_NewDiskCB;
 static __fi ElfObject* loadElf(const wxString filename)
 {
 	if (filename.StartsWith(L"host"))
-		return new ElfObject(filename.After(':'), Path::GetFileSize(filename.After(':').ToStdString()));
+		return new ElfObject(filename.After(':'), Path::GetFileSize(Path::FromWxString(filename.After(':'))));
 
 	// Mimic PS2 behavior!
 	// Much trial-and-error with changing the ISOFS and BOOT2 contents of an image have shown that

--- a/pcsx2/CDVD/CDVDaccess.cpp
+++ b/pcsx2/CDVD/CDVDaccess.cpp
@@ -395,7 +395,7 @@ bool DoCDVDopen()
 	if (g_Conf->CurrentBlockdump.empty())
 			g_Conf->CurrentBlockdump = wxGetCwd();
 
-	wxString temp(Path::Combine(g_Conf->CurrentBlockdump, somepick.ToStdString()));
+	wxString temp = Path::ToWxString(Path::Combine(g_Conf->CurrentBlockdump, Path::FromWxString(somepick)));
 
 #ifdef ENABLE_TIMESTAMPS
 	wxDateTime curtime(wxDateTime::GetTimeNow());

--- a/pcsx2/CDVD/GzippedFileReader.cpp
+++ b/pcsx2/CDVD/GzippedFileReader.cpp
@@ -143,11 +143,15 @@ static wxString ApplyTemplate(const wxString& name, const wxDirName& base,
 
 	wxString fname(filename);
 	if (first > 0)
-		fname = Path::GetFilename(fname.ToStdString()); // without path
+		fname = Path::ToWxString(Path::FromWxString(fname).filename()); // without path
 
 	tem.Replace(key, fname);
 	if (first > 0)
-		tem = Path::Combine(base.ToString().ToStdString(), tem.ToStdString()); // ignores appRoot if tem is absolute
+	{
+		// ignores appRoot if tem is absolute
+		fs::path path = Path::Combine(Path::FromWxString(base.ToString()), Path::FromWxString(tem));
+		tem = Path::ToWxString(path);
+	}
 
 	return tem;
 }

--- a/pcsx2/Darwin/DarwinFlatFileReader.cpp
+++ b/pcsx2/Darwin/DarwinFlatFileReader.cpp
@@ -125,5 +125,5 @@ void FlatFileReader::Close(void)
 
 uint FlatFileReader::GetBlockCount(void) const
 {
-	return (int)(Path::GetFileSize(static_cast<std::string>(m_filename)) / m_blocksize);
+	return (int)(Path::GetFileSize(Path::FromWxString(m_filename)) / m_blocksize);
 }

--- a/pcsx2/Dump.cpp
+++ b/pcsx2/Dump.cpp
@@ -209,7 +209,8 @@ void iDumpBlock(u32 ee_pc, u32 ee_size, uptr x86_pc, u32 x86_size)
 	DbgCon.WriteLn( Color_Gray, "dump block %x:%x (x86:0x%x)", ee_pc, ee_end, x86_pc );
 
 	Path::CreateFolder(g_Conf->Folders.Logs);
-	wxString dump_filename = Path::Combine( g_Conf->Folders.Logs, wxsFormat(L"R5900dump_%.8X:%.8X.txt", ee_pc, ee_end).ToStdString() );
+	fs::path dump_path = Path::Combine(g_Conf->Folders.Logs, Path::FromWxString(wxsFormat(L"R5900dump_%.8X:%.8X.txt", ee_pc, ee_end)));
+	wxString dump_filename = Path::ToWxString(dump_path);
 	AsciiFile eff( dump_filename, L"w" );
 
 	// Print register content to detect the memory access type. Warning value are taken
@@ -247,7 +248,7 @@ void iDumpBlock(u32 ee_pc, u32 ee_size, uptr x86_pc, u32 x86_size)
 
 	// handy but slow solution (system call)
 #ifdef __linux__
-	wxString obj_filename = Path::Combine(g_Conf->Folders.Logs, "objdump_tmp.o");
+	wxString obj_filename = Path::ToWxString(Path::Combine(g_Conf->Folders.Logs, "objdump_tmp.o"));
 	wxFFile objdump(obj_filename , L"wb");
 	objdump.Write(x86, x86_size);
 	objdump.Close();
@@ -274,8 +275,7 @@ void iDumpBlock( int startpc, u8 * ptr )
 
 	Path::CreateFolder(g_Conf->Folders.Logs);
 	AsciiFile eff(
-		Path::Combine( g_Conf->Folders.Logs, wxsFormat(L"R5900dump%.8X.txt", startpc).ToStdString() ), L"w"
-	);
+		Path::ToWxString(Path::Combine(g_Conf->Folders.Logs, Path::FromWxString(wxsFormat(L"R5900dump%.8X.txt", startpc)))), L"w");
 
 	if (!symbolMap.GetLabelString(startpc).empty())
 	{

--- a/pcsx2/Linux/LnxFlatFileReader.cpp
+++ b/pcsx2/Linux/LnxFlatFileReader.cpp
@@ -96,5 +96,5 @@ void FlatFileReader::Close(void)
 
 uint FlatFileReader::GetBlockCount(void) const
 {
-	return (int)(Path::GetFileSize(m_filename.ToStdString()) / m_blocksize);
+	return (int)(Path::GetFileSize(Path::FromWxString(m_filename)) / m_blocksize);
 }

--- a/pcsx2/PAD/Linux/ini.cpp
+++ b/pcsx2/PAD/Linux/ini.cpp
@@ -43,7 +43,7 @@ void PADSaveConfig()
 	FILE* f;
 
 	std::string iniName("PAD.ini");
-	const std::string iniFile = std::string(Path::Combine(GetSettingsFolder(), iniName)); // default path, just in case
+	const std::string iniFile = Path::Combine(GetSettingsFolder(), iniName).string(); // default path, just in case
 	f = fopen(iniFile.c_str(), "w");
 	if (f == NULL)
 	{

--- a/pcsx2/PAD/Windows/PADConfig.cpp
+++ b/pcsx2/PAD/Windows/PADConfig.cpp
@@ -342,7 +342,7 @@ void PADsetSettingsDir(const char* dir)
 
 	//uint targlen = MultiByteToWideChar(CP_ACP, 0, dir, -1, NULL, 0);
 	std::string iniName = "PAD.ini";
-	MultiByteToWideChar(CP_UTF8, 0, wxString(Path::Combine(GetSettingsFolder(), iniName)).c_str(), -1, iniFileUSB, MAX_PATH * 2);
+	MultiByteToWideChar(CP_UTF8, 0, Path::ToWxString(Path::Combine(GetSettingsFolder(), iniName)).c_str(), -1, iniFileUSB, MAX_PATH * 2);
 
 	createIniDir = false;
 

--- a/pcsx2/Patch.cpp
+++ b/pcsx2/Patch.cpp
@@ -187,7 +187,8 @@ static int _LoadPatchFiles(const wxDirName& folderName, wxString& fileSpec, cons
 		{
 			PatchesCon->WriteLn(Color_Green, L"Found %s file: '%s'", WX_STR(friendlyName), WX_STR(buffer));
 			int before = Patch.size();
-			f.Open(Path::Combine(dir.GetName().ToStdString(), buffer.ToStdString()));
+			fs::path path = Path::Combine(Path::FromWxString(dir.GetName()), Path::FromWxString(buffer));
+			f.Open(Path::ToWxString(path));
 			inifile_process(f);
 			f.Close();
 			int loaded = Patch.size() - before;
@@ -249,7 +250,8 @@ int LoadPatchesFromDir(wxString name, const wxDirName& folderName, const wxStrin
 	// This check only tests the default cheats folder, so the message it produces is possibly misleading.
 	if (folderName.ToString().IsSameAs(Path::ToWxString(PathDefs::GetCheats())) && numberFoundPatchFiles == 0)
 	{
-		wxString pathName = Path::Combine(folderName.ToString().ToStdString(), (name.MakeUpper().ToStdString() + ".pnach"));
+		fs::path filename = Path::FromWxString(name.MakeUpper()).replace_extension("pnach");
+		wxString pathName = Path::ToWxString(Path::Combine(Path::FromWxString(folderName.ToString()), filename));
 		PatchesCon->WriteLn(Color_Gray, L"Not found %s file: %s", WX_STR(friendlyName), WX_STR(pathName));
 	}
 

--- a/pcsx2/SPU2/Debug.h
+++ b/pcsx2/SPU2/Debug.h
@@ -16,6 +16,8 @@
 #ifndef DEBUG_H_INCLUDED
 #define DEBUG_H_INCLUDED
 
+#include "Utilities/PathUtils.h"
+
 extern FILE* spu2Log;
 
 extern void FileLog(const char* fmt, ...);
@@ -23,9 +25,9 @@ extern void ConLog(const char* fmt, ...);
 
 extern void DoFullDump();
 
-extern FILE* OpenBinaryLog(const std::string& logfile);
-extern FILE* OpenLog(const std::string& logfile);
-extern FILE* OpenDump(const std::string& logfile);
+extern FILE* OpenBinaryLog(const fs::path& logfile);
+extern FILE* OpenLog(const fs::path& logfile);
+extern FILE* OpenDump(const fs::path& logfile);
 
 namespace WaveDump
 {

--- a/pcsx2/SPU2/Dma.cpp
+++ b/pcsx2/SPU2/Dma.cpp
@@ -17,6 +17,7 @@
 #include "Global.h"
 #include "Dma.h"
 #include "IopCommon.h"
+#include "Utilities/PathUtils.h"
 
 #include "spu2.h" // temporary until I resolve cyclePtr/TimeUpdate dependencies.
 
@@ -34,8 +35,8 @@ void DMALogOpen()
 {
 	if (!DMALog())
 		return;
-	DMA4LogFile = OpenBinaryLog(DMA4LogFileName.ToStdString());
-	DMA7LogFile = OpenBinaryLog(DMA7LogFileName.ToStdString());
+	DMA4LogFile = OpenBinaryLog(Path::FromWxString(DMA4LogFileName));
+	DMA7LogFile = OpenBinaryLog(Path::FromWxString(DMA7LogFileName));
 	ADMA4LogFile = OpenBinaryLog("adma4.raw");
 	ADMA7LogFile = OpenBinaryLog("adma7.raw");
 	ADMAOutLogFile = OpenBinaryLog("admaOut.raw");

--- a/pcsx2/SPU2/Linux/CfgHelpers.cpp
+++ b/pcsx2/SPU2/Linux/CfgHelpers.cpp
@@ -26,7 +26,7 @@ void initIni()
 {
 	if (!pathSet)
 	{
-		path = Path::Combine(GetSettingsFolder().string(), path.ToStdString());
+		path = Path::ToWxString(Path::Combine(GetSettingsFolder(), Path::FromWxString(path)));
 		pathSet = true;
 	}
 	if (spuConfig == nullptr)
@@ -42,7 +42,7 @@ void setIni(const wchar_t* Section)
 void CfgSetSettingsDir(const char* dir)
 {
 	FileLog("CfgSetSettingsDir(%s)\n", dir);
-	path = Path::Combine((dir == nullptr) ? "inis" : std::string(dir), "SPU2.ini");
+	path = Path::ToWxString(Path::Combine((dir == nullptr) ? "inis" : std::string(dir), "SPU2.ini"));
 	pathSet = true;
 }
 

--- a/pcsx2/SPU2/Linux/ConfigDebug.cpp
+++ b/pcsx2/SPU2/Linux/ConfigDebug.cpp
@@ -40,8 +40,8 @@ bool _RegDump = false;
 // the configured crap in the ini file.
 static bool LogLocationSetByPcsx2 = false;
 
-static std::string LogsFolder;
-static std::string DumpsFolder;
+static fs::path LogsFolder;
+static fs::path DumpsFolder;
 
 wxString AccessLogFileName;
 wxString WaveLogFileName;
@@ -59,19 +59,19 @@ void CfgSetLogDir(const char* dir)
 	LogLocationSetByPcsx2 = (dir != nullptr);
 }
 
-FILE* OpenBinaryLog(const std::string& logfile)
+FILE* OpenBinaryLog(const fs::path& logfile)
 {
-	return wxFopen(Path::Combine(LogsFolder, logfile), L"wb");
+	return wxFopen(Path::ToWxString(Path::Combine(LogsFolder, logfile)), L"wb");
 }
 
-FILE* OpenLog(const std::string& logfile)
+FILE* OpenLog(const fs::path& logfile)
 {
-	return wxFopen(Path::Combine(LogsFolder, logfile), L"w");
+	return wxFopen(Path::ToWxString(Path::Combine(LogsFolder, logfile)), L"w");
 }
 
-FILE* OpenDump(const std::string& logfile)
+FILE* OpenDump(const fs::path& logfile)
 {
-	return wxFopen(Path::Combine(DumpsFolder, logfile), L"w");
+	return wxFopen(Path::ToWxString(Path::Combine(DumpsFolder, logfile)), L"w");
 }
 
 namespace DebugConfig

--- a/pcsx2/SPU2/Windows/CfgHelpers.cpp
+++ b/pcsx2/SPU2/Windows/CfgHelpers.cpp
@@ -51,14 +51,14 @@ void SysMessage(const wchar_t* fmt, ...)
 
 #include "Utilities/PathUtils.h"
 
-std::string CfgFile("SPU2.ini");
+fs::path CfgFile("SPU2.ini");
 bool pathSet = false;
 
 void initIni()
 {
 	if (!pathSet)
 	{
-		CfgFile = Path::Combine(GetSettingsFolder().string(), CfgFile);
+		CfgFile = Path::Combine(GetSettingsFolder(), CfgFile);
 		pathSet = true;
 	}
 }
@@ -88,7 +88,7 @@ void CfgWriteBool(const TCHAR* Section, const TCHAR* Name, bool Value)
 {
 	initIni();
 	const TCHAR* Data = Value ? L"TRUE" : L"FALSE";
-	WritePrivateProfileString(Section, Name, Data, wxString(CfgFile));
+	WritePrivateProfileString(Section, Name, Data, Path::ToWxString(CfgFile));
 }
 
 void CfgWriteInt(const TCHAR* Section, const TCHAR* Name, int Value)
@@ -96,7 +96,7 @@ void CfgWriteInt(const TCHAR* Section, const TCHAR* Name, int Value)
 	initIni();
 	TCHAR Data[32];
 	_itow(Value, Data, 10);
-	WritePrivateProfileString(Section, Name, Data, wxString(CfgFile));
+	WritePrivateProfileString(Section, Name, Data, Path::ToWxString(CfgFile));
 }
 
 void CfgWriteFloat(const TCHAR* Section, const TCHAR* Name, float Value)
@@ -104,7 +104,7 @@ void CfgWriteFloat(const TCHAR* Section, const TCHAR* Name, float Value)
 	initIni();
 	TCHAR Data[32];
 	_swprintf(Data, L"%f", Value);
-	WritePrivateProfileString(Section, Name, Data, wxString(CfgFile));
+	WritePrivateProfileString(Section, Name, Data, Path::ToWxString(CfgFile));
 }
 
 /*void CfgWriteStr(const TCHAR* Section, const TCHAR* Name, const TCHAR *Data)
@@ -115,7 +115,7 @@ WritePrivateProfileString( Section, Name, Data, CfgFile );
 void CfgWriteStr(const TCHAR* Section, const TCHAR* Name, const wxString& Data)
 {
 	initIni();
-	WritePrivateProfileString(Section, Name, Data, wxString(CfgFile));
+	WritePrivateProfileString(Section, Name, Data, Path::ToWxString(CfgFile));
 }
 
 /*****************************************************************************/
@@ -125,7 +125,7 @@ bool CfgReadBool(const TCHAR* Section, const TCHAR* Name, bool Default)
 	initIni();
 	TCHAR Data[255] = {0};
 
-	GetPrivateProfileString(Section, Name, L"", Data, 255, wxString(CfgFile));
+	GetPrivateProfileString(Section, Name, L"", Data, 255, Path::ToWxString(CfgFile));
 	Data[254] = 0;
 	if (wcslen(Data) == 0)
 	{
@@ -151,7 +151,7 @@ int CfgReadInt(const TCHAR* Section, const TCHAR* Name, int Default)
 {
 	initIni();
 	TCHAR Data[255] = {0};
-	GetPrivateProfileString(Section, Name, L"", Data, 255, wxString(CfgFile));
+	GetPrivateProfileString(Section, Name, L"", Data, 255, Path::ToWxString(CfgFile));
 	Data[254] = 0;
 
 	if (wcslen(Data) == 0)
@@ -167,7 +167,7 @@ float CfgReadFloat(const TCHAR* Section, const TCHAR* Name, float Default)
 {
 	initIni();
 	TCHAR Data[255] = {0};
-	GetPrivateProfileString(Section, Name, L"", Data, 255, wxString(CfgFile));
+	GetPrivateProfileString(Section, Name, L"", Data, 255, Path::ToWxString(CfgFile));
 	Data[254] = 0;
 
 	if (wcslen(Data) == 0)
@@ -182,7 +182,7 @@ float CfgReadFloat(const TCHAR* Section, const TCHAR* Name, float Default)
 void CfgReadStr(const TCHAR* Section, const TCHAR* Name, TCHAR* Data, int DataSize, const TCHAR* Default)
 {
 	initIni();
-	GetPrivateProfileString(Section, Name, L"", Data, DataSize, wxString(CfgFile));
+	GetPrivateProfileString(Section, Name, L"", Data, DataSize, Path::ToWxString(CfgFile));
 
 	if (wcslen(Data) == 0)
 	{
@@ -195,7 +195,7 @@ void CfgReadStr(const TCHAR* Section, const TCHAR* Name, wxString& Data, const T
 {
 	initIni();
 	wchar_t workspace[512];
-	GetPrivateProfileString(Section, Name, L"", workspace, ArraySize(workspace), wxString(CfgFile));
+	GetPrivateProfileString(Section, Name, L"", workspace, ArraySize(workspace), Path::ToWxString(CfgFile));
 
 	Data = workspace;
 
@@ -213,7 +213,7 @@ bool CfgFindName(const TCHAR* Section, const TCHAR* Name)
 	initIni();
 	// Only load 24 characters.  No need to load more.
 	TCHAR Data[24] = {0};
-	GetPrivateProfileString(Section, Name, L"", Data, 24, wxString(CfgFile));
+	GetPrivateProfileString(Section, Name, L"", Data, 24, Path::ToWxString(CfgFile));
 	Data[23] = 0;
 
 	if (wcslen(Data) == 0)

--- a/pcsx2/SPU2/Windows/ConfigDebug.cpp
+++ b/pcsx2/SPU2/Windows/ConfigDebug.cpp
@@ -16,7 +16,7 @@
 #include "PrecompiledHeader.h"
 #include "../Global.h"
 #include "Dialogs.h"
-#include "Utilities\PathUtils.h"
+#include "Utilities/PathUtils.h"
 
 
 bool DebugEnabled = false;
@@ -58,24 +58,24 @@ wxString RegDumpFileName;
 
 void CfgSetLogDir(const char* dir)
 {
-	LogsFolder = ((dir == nullptr) ? wxString(L"logs") : wxString(dir, wxConvFile)).ToStdString();
-	DumpsFolder = ((dir == nullptr) ? wxString(L"logs") : wxString(dir, wxConvFile)).ToStdString();
+	LogsFolder = Path::FromWxString(((dir == nullptr) ? wxString(L"logs") : wxString(dir, wxConvFile)));
+	DumpsFolder = Path::FromWxString(((dir == nullptr) ? wxString(L"logs") : wxString(dir, wxConvFile)));
 	LogLocationSetByPcsx2 = (dir != nullptr);
 }
 
-FILE* OpenBinaryLog(const std::string& logfile)
+FILE* OpenBinaryLog(const fs::path& logfile)
 {
-	return wxFopen(Path::ToWxString(Path::Combine(LogsFolder.string(), logfile)), L"wb");
+	return wxFopen(Path::ToWxString(Path::Combine(LogsFolder, logfile)), L"wb");
 }
 
-FILE* OpenLog(const std::string& logfile)
+FILE* OpenLog(const fs::path& logfile)
 {
-	return wxFopen(Path::ToWxString(Path::Combine(LogsFolder.string(), logfile)), L"w");
+	return wxFopen(Path::ToWxString(Path::Combine(LogsFolder, logfile)), L"w");
 }
 
-FILE* OpenDump(const std::string& logfile)
+FILE* OpenDump(const fs::path& logfile)
 {
-	return wxFopen(Path::ToWxString(Path::Combine(DumpsFolder.string(), logfile)), L"w");
+	return wxFopen(Path::ToWxString(Path::Combine(DumpsFolder, logfile)), L"w");
 }
 
 namespace DebugConfig
@@ -117,8 +117,8 @@ namespace DebugConfig
 
 		if (!LogLocationSetByPcsx2)
 		{
-			LogsFolder = CfgLogsFolder.ToStdString();
-			DumpsFolder = CfgLogsFolder.ToStdString();
+			LogsFolder = Path::FromWxString(CfgLogsFolder);
+			DumpsFolder = Path::FromWxString(CfgLogsFolder);
 		}
 	}
 

--- a/pcsx2/SPU2/spu2.cpp
+++ b/pcsx2/SPU2/spu2.cpp
@@ -242,7 +242,7 @@ s32 SPU2init()
 #ifdef SPU2_LOG
 	if (AccessLog())
 	{
-		spu2Log = OpenLog(AccessLogFileName.ToStdString());
+		spu2Log = OpenLog(Path::FromWxString(AccessLogFileName));
 		setvbuf(spu2Log, nullptr, _IONBF, 0);
 		FileLog("SPU2init\n");
 	}

--- a/pcsx2/SaveState.cpp
+++ b/pcsx2/SaveState.cpp
@@ -57,7 +57,10 @@ wxString SaveStateBase::GetFilename( int slot )
 	wxString serialName( DiscSerial );
 	if (serialName.IsEmpty()) serialName = L"BIOS";
 
-	return ( Path::Combine(g_Conf->Folders.Savestates.string(), static_cast<wxString>(pxsFmt( L"%s (%08X).%02d.p2s", WX_STR(serialName), ElfCRC, slot )).ToStdString()));
+	wxString savestateFile = static_cast<wxString>(pxsFmt(L"%s (%08X).%02d.p2s", WX_STR(serialName), ElfCRC, slot));
+	fs::path path = Path::Combine(g_Conf->Folders.Savestates, Path::FromWxString(savestateFile));
+
+	return Path::ToWxString(path);
 
 	//return (g_Conf->Folders.Savestates +
 	//	pxsFmt( L"%08X.%03d", ElfCRC, slot )).GetFullPath();

--- a/pcsx2/USB/configuration.cpp
+++ b/pcsx2/USB/configuration.cpp
@@ -35,9 +35,9 @@ void USBsetSettingsDir()
 	if(!USBpathSet)
 	{
 #ifdef _WIN32
-		IniPath = fs::path(Path::Combine(GetSettingsFolder(), fs::path(iniFile))).wstring(); // default path, just in case
+		IniPath = Path::Combine(GetSettingsFolder(), iniFile).wstring(); // default path, just in case
 #else
-		IniPath = Path::Combine(GetSettingsFolder(), fs::path(iniFile)); // default path, just in case
+		IniPath = Path::Combine(GetSettingsFolder(), iniFile).string(); // default path, just in case
 #endif
 		USBpathSet = true;
 	}

--- a/pcsx2/gui/App.h
+++ b/pcsx2/gui/App.h
@@ -604,7 +604,7 @@ public:
 	void CleanupRestartable();
 	void CleanupResources();
 	void WipeUserModeSettings();
-	bool TestUserPermissionsRights(const std::string& testFolder);
+	bool TestUserPermissionsRights(const fs::path& testFolder);
 	void EstablishAppUserMode();
 	void ForceFirstTimeWizardOnNextRun();
 

--- a/pcsx2/gui/AppConfig.cpp
+++ b/pcsx2/gui/AppConfig.cpp
@@ -150,7 +150,7 @@ namespace PathDefs
 			// Move all user data file into central configuration directory (XDG_CONFIG_DIR)
 			case DocsFolder_User:	return GetUserLocalDataDir();
 #else
-			case DocsFolder_User:	return Path::Combine(wxStandardPaths::Get().GetDocumentsDir().ToStdString(), pxGetAppName().ToStdString());
+			case DocsFolder_User:	return Path::Combine(Path::FromWxString(wxStandardPaths::Get().GetDocumentsDir()), Path::FromWxString(pxGetAppName()));
 #endif
 			case DocsFolder_Custom: return CustomDocumentsFolder;
 
@@ -180,37 +180,37 @@ namespace PathDefs
 
 	fs::path GetSnapshots()
 	{
-		return (GetDocuments() / "snaps").make_preferred();
+		return Path::Combine(GetDocuments(), "snaps");
 	}
 
 	fs::path GetBios()
 	{
-		return (GetDocuments() / "bios").make_preferred();
+		return Path::Combine(GetDocuments(), "bios");
 	}
 
 	fs::path GetCheats()
 	{
-		return (GetDocuments() / "cheats").make_preferred();
+		return Path::Combine(GetDocuments(), "cheats");
 	}
 
 	fs::path GetCheatsWS()
 	{
-		return (GetDocuments() / "cheats_ws").make_preferred();
+		return Path::Combine(GetDocuments(), "cheats_ws");
 	}
 
 	fs::path GetDocs()
 	{
-		return (AppRoot().parent_path() / "docs").make_preferred();
+		return Path::Combine(GetDocuments(), "docs");
 	}
 
 	fs::path GetSavestates()
 	{
-		return (GetDocuments() / "sstates").make_preferred();
+		return Path::Combine(GetDocuments(), "sstates");
 	}
 
 	fs::path GetMemoryCards()
 	{
-		return (GetDocuments() / "memcards").make_preferred();
+		return Path::Combine(GetDocuments(), "memcards");
 	}
 
 	fs::path GetPlugins()
@@ -218,30 +218,29 @@ namespace PathDefs
 		// Each linux distributions have his rules for path so we give them the possibility to
 		// change it with compilation flags. -- Gregory
 #ifndef PLUGIN_DIR_COMPILATION
-		return (AppRoot() / "plugins").make_preferred();
+		return Path::Combine(AppRoot(), "plugins");
 #else
 #define xPLUGIN_DIR_str(s) PLUGIN_DIR_str(s)
 #define PLUGIN_DIR_str(s) #s
-		return std::string( xPLUGIN_DIR_str(PLUGIN_DIR_COMPILATION) );
+		return fs::path(std::string(xPLUGIN_DIR_str(PLUGIN_DIR_COMPILATION)));
 #endif
 	}
 
 	fs::path GetSettings()
 	{
-		fs::path docPath = GetDocuments();
-		fs::path path = GetDocuments() / "settings";
+		fs::path path = Path::Combine(GetDocuments(), "settings");
 		SettingsFolder = path;
 		return path;
 	}
 
 	fs::path GetLogs()
 	{
-		return (GetDocuments() / "logs").make_preferred();
+		return Path::Combine(GetDocuments(), "logs");
 	}
 
 	fs::path GetLangs()
 	{
-		return (PathDefs::AppRoot() / "Langs").make_preferred();
+		return Path::Combine(AppRoot(), "Langs");
 	}
 
 	fs::path Get( FoldersEnum_t folderidx )
@@ -436,7 +435,7 @@ fs::path AppConfig::FullpathTo( PluginsEnum_t pluginidx ) const
 // returns true if the filenames are quite absolutely the equivalent.  Works for all
 // types of filenames, relative and absolute.  Very important that you use this function
 // rather than any other type of more direct string comparison!
-bool AppConfig::FullpathMatchTest( PluginsEnum_t pluginId, const std::string& cmpto ) const
+bool AppConfig::FullpathMatchTest( PluginsEnum_t pluginId, const fs::path& cmpto ) const
 {
 	// Implementation note: wxFileName automatically normalizes things as needed in it's
 	// equality comparison implementations, so we can do a simple comparison as follows:
@@ -474,27 +473,34 @@ fs::path GetSettingsFolder()
 
 fs::path GetVmSettingsFilename()
 {
-	fs::path fname( !wxGetApp().Overrides.VmSettingsFile.GetFullPath().ToStdString().empty() ? wxGetApp().Overrides.VmSettingsFile.GetFullPath().ToStdString() : FilenameDefs::GetVmConfig().GetFullPath().ToStdString() );
+	fs::path fname = Path::FromWxString(FilenameDefs::GetVmConfig().GetFullPath());
+	if (wxGetApp().Overrides.VmSettingsFile.IsOk())
+	{
+		fname = Path::FromWxString(wxGetApp().Overrides.VmSettingsFile.GetFullPath());
+	}
 	return Path::Combine(GetSettingsFolder(), fname);
 }
 
 fs::path GetUiSettingsFilename()
 {
-	fs::path fname( FilenameDefs::GetUiConfig().GetFullPath().ToStdString() );
-	return (GetSettingsFolder() / fname ).make_preferred();
+	fs::path fname = Path::FromWxString(FilenameDefs::GetUiConfig().GetFullPath());
+	return Path::Combine(GetSettingsFolder(), fname);
 }
 
 fs::path GetUiKeysFilename()
 {
-	fs::path fname( FilenameDefs::GetUiKeysConfig().GetFullPath().ToStdString() );
-	return (GetSettingsFolder() / fname).make_preferred();
+	fs::path fname = Path::FromWxString(FilenameDefs::GetUiKeysConfig().GetFullPath());
+	return Path::Combine(GetSettingsFolder(), fname);
 }
 
-fs::path AppConfig::FullpathToBios() const				{ return Folders.Bios / BaseFilenames.Bios; }
-
-fs::path AppConfig::FullpathToMcd( uint slot ) const
+fs::path AppConfig::FullpathToBios() const
 {
-	return Folders.MemoryCards / Mcd[slot].Filename;
+	return Path::Combine(Folders.Bios, BaseFilenames.Bios);
+}
+
+fs::path AppConfig::FullpathToMcd(uint slot) const
+{
+	return Path::Combine(Folders.MemoryCards, Mcd[slot].Filename);
 }
 
 bool IsPortable()
@@ -533,7 +539,7 @@ AppConfig::AppConfig()
 	for( uint slot=0; slot<8; ++slot )
 	{
 		Mcd[slot].Enabled	= !FileMcd_IsMultitapSlot(slot);	// enables main 2 slots
-		Mcd[slot].Filename	= FileMcd_GetDefaultName( slot ).ToStdString();
+		Mcd[slot].Filename	= Path::FromWxString(FileMcd_GetDefaultName( slot ));
 
 		// Folder memory card is autodetected later.
 		Mcd[slot].Type = MemoryCardType::MemoryCard_File;
@@ -565,7 +571,7 @@ void App_LoadSaveInstallSettings( IniInterface& ini )
 
     wxString CustomDoc = Path::ToWxString(CustomDocumentsFolder);
     wxString Setting = Path::ToWxString(SettingsFolder);
-    wxFileName InstallF(InstallFolder);
+    wxFileName InstallF(Path::ToWxString(InstallFolder));
 
 	ini.EnumEntry( L"DocumentsFolderMode",	DocsFolderMode,	DocsFolderModeNames, (InstallationMode == InstallMode_Registered) ? DocsFolder_User : DocsFolder_Custom);
 
@@ -642,7 +648,7 @@ void AppConfig::LoadSaveRootItems( IniInterface& ini )
 
 	wxFileName res(Path::ToWxString(CurrentIso));
 	ini.Entry( L"CurrentIso", res, res, ini.IsLoading() || IsPortable() );
-	CurrentIso = res.GetFullPath().ToStdWstring();
+	CurrentIso = Path::FromWxString(res.GetFullPath());
 
 	IniEntry( CurrentBlockdump );
 	IniEntry( CurrentELF );
@@ -781,7 +787,8 @@ void AppConfig::FolderOptions::LoadSave( IniInterface& ini )
 	IniEntryDirFile( Langs,  rel );
 	IniEntryDirFile( Cheats, rel );
 	IniEntryDirFile( CheatsWS, rel );
-	ini.Entry( L"PluginsFolder", PluginsFolder, InstallFolder + PathDefs::Base::Plugins(), rel );
+	// TODO - verify this refactor, this append seems potentially buggy
+	ini.Entry( L"PluginsFolder", PluginsFolder, Path::Combine(InstallFolder, PathDefs::Base::Plugins()), rel );
 
 	IniEntryDirFile( RunIso, rel );
 	IniEntryDirFile( RunELF, rel );
@@ -1136,7 +1143,7 @@ void RelocateLogfile()
 {
 	Path::CreateFolder(g_Conf->Folders.Logs);
 
-	wxString newlogname( Path::Combine( g_Conf->Folders.Logs.string(), "emuLog.txt" ) );
+	wxString newlogname = Path::ToWxString(Path::Combine(g_Conf->Folders.Logs, "emuLog.txt"));
 
 	if( (emuLog != NULL) && (emuLogName != newlogname) )
 	{

--- a/pcsx2/gui/AppConfig.h
+++ b/pcsx2/gui/AppConfig.h
@@ -63,7 +63,7 @@ extern bool				UseDefaultPluginsFolder;
 extern fs::path		CustomDocumentsFolder;		// allows the specification of a custom home folder for PCSX2 documents files.
 extern fs::path		SettingsFolder;				// dictates where the settings folder comes from, *if* UseDefaultSettingsFolder is FALSE.
 
-extern std::string		InstallFolder;
+extern fs::path		InstallFolder;
 extern fs::path		PluginsFolder;
 
 extern fs::path  GetSettingsFolder();
@@ -377,7 +377,7 @@ public:
 	fs::path FullpathToMcd( uint slot ) const;
 	fs::path FullpathTo( PluginsEnum_t pluginId ) const;
 
-	bool FullpathMatchTest( PluginsEnum_t pluginId, const std::string& cmpto ) const;
+	bool FullpathMatchTest( PluginsEnum_t pluginId, const fs::path& cmpto ) const;
 
 	void LoadSave( IniInterface& ini );
 	void LoadSaveRootItems( IniInterface& ini );

--- a/pcsx2/gui/AppCoreThread.cpp
+++ b/pcsx2/gui/AppCoreThread.cpp
@@ -497,7 +497,7 @@ static void _ApplySettings(const Pcsx2Config& src, Pcsx2Config& fixup)
 		else
 		{
 			// No ws cheat files found at the cheats_ws folder, try the ws cheats zip file.
-			wxString cheats_ws_archive = Path::ToWxString(Path::Combine(PathDefs::GetProgramDataDir().string(), "cheats_ws.zip"));
+			wxString cheats_ws_archive = Path::ToWxString(Path::Combine(PathDefs::GetProgramDataDir(), "cheats_ws.zip"));
 			int numberDbfCheatsLoaded = LoadPatchesFromZip(gameCRC, cheats_ws_archive);
 			PatchesCon->WriteLn(Color_Green, "(Wide Screen Cheats DB) Patches Loaded: %d", numberDbfCheatsLoaded);
 			gameWsHacks.Printf(L" [%d widescreen hacks]", numberDbfCheatsLoaded);

--- a/pcsx2/gui/AppGameDatabase.cpp
+++ b/pcsx2/gui/AppGameDatabase.cpp
@@ -27,7 +27,7 @@ std::ifstream AppGameDatabase::getFileAsStream(const fs::path& file)
 #ifdef _WIN32
 	return std::ifstream(file.wstring());
 #else
-	return std::ifstream(file.string());
+	return std::ifstream(file);
 #endif
 }
 
@@ -46,7 +46,7 @@ AppGameDatabase& AppGameDatabase::LoadFromFile(const fs::path& _file)
 		//           So the games DB was really the only one that suffers from residues of prior installs.
 
 		//wxDirName dir = InstallFolder;
-		fs::path dir(wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath().ToStdWstring());
+		fs::path dir = Path::FromWxString(wxFileName(wxStandardPaths::Get().GetExecutablePath()).GetPath());
 		file = (dir.parent_path() / file);
 	}
 

--- a/pcsx2/gui/AppGameDatabase.h
+++ b/pcsx2/gui/AppGameDatabase.h
@@ -32,7 +32,7 @@ public:
 		DESTRUCTOR_CATCHALL
 	}
 
-	AppGameDatabase& LoadFromFile(const fs::path& file = PathDefs::GetProgramDataDir() / "GameIndex.yaml");
+	AppGameDatabase& LoadFromFile(const fs::path& file = Path::Combine(PathDefs::GetProgramDataDir(), "GameIndex.yaml"));
 
 private:
 	std::ifstream getFileAsStream(const fs::path& file);

--- a/pcsx2/gui/AppInit.cpp
+++ b/pcsx2/gui/AppInit.cpp
@@ -311,7 +311,7 @@ bool Pcsx2App::ParseOverrides(wxCmdLineParser& parser)
 			}
 
 			if (parsed)
-				Overrides.Filenames.Plugins[pi->id] = fs::path(dest.ToStdWstring());
+				Overrides.Filenames.Plugins[pi->id] = Path::FromWxString(dest);
 		}
 	});
 

--- a/pcsx2/gui/AppMain.cpp
+++ b/pcsx2/gui/AppMain.cpp
@@ -427,7 +427,7 @@ class Pcsx2StandardPaths : public wxStandardPaths
 public:
 	wxString GetResourcesDir() const
 	{
-		return Path::Combine( GetDataDir().ToStdString(), "Langs" );
+		return Path::Combine( Path::FromWxString(GetDataDir()), "Langs" );
 	}
 
 #ifdef __POSIX__
@@ -436,23 +436,30 @@ public:
 		// I got memory corruption inside wxGetEnv when I heavily toggle the GS renderer (F9). It seems wxGetEnv
 		// isn't thread safe? To avoid any issue on this read only variable, I cache the result.
 		static wxString cache_dir;
-		if (!cache_dir.IsEmpty()) return cache_dir;
+		if (!cache_dir.IsEmpty())
+			return cache_dir;
 
 		// Note: GetUserLocalDataDir() on linux return $HOME/.pcsx2 unfortunately it does not follow the XDG standard
 		// So we re-implement it, to follow the standard.
 		wxDirName user_local_dir;
-		wxDirName default_config_dir = (wxDirName)Path::Combine( ".config", pxGetAppName().ToStdString() );
+		wxDirName default_config_dir = wxDirName(Path::ToWxString(Path::Combine(".config", Path::FromWxString(pxGetAppName()))));
 		wxString xdg_home_value;
-		if( wxGetEnv(L"XDG_CONFIG_HOME", &xdg_home_value) ) {
-			if ( xdg_home_value.IsEmpty() ) {
+		if (wxGetEnv(L"XDG_CONFIG_HOME", &xdg_home_value))
+		{
+			if (xdg_home_value.IsEmpty())
+			{
 				// variable exist but it is empty. So use the default value
-				user_local_dir = (wxDirName)Path::Combine( GetUserConfigDir().ToStdString() , default_config_dir.ToString().ToStdString() );
-			} else {
-				user_local_dir = (wxDirName)Path::Combine( xdg_home_value.ToStdString(), pxGetAppName().ToStdString());
+				user_local_dir = wxDirName(Path::ToWxString(Path::Combine(Path::FromWxString(GetUserConfigDir()), Path::FromWxString(default_config_dir.ToString()))));
 			}
-		} else {
+			else
+			{
+				user_local_dir = wxDirName(Path::ToWxString(Path::Combine(Path::FromWxString(xdg_home_value), Path::FromWxString(pxGetAppName()))));
+			}
+		}
+		else
+		{
 			// variable do not exist
-			user_local_dir = (wxDirName)Path::Combine( GetUserConfigDir().ToStdString() , default_config_dir.ToString().ToStdString() );
+			user_local_dir = wxDirName(Path::ToWxString(Path::Combine(Path::FromWxString(GetUserConfigDir()), Path::FromWxString(default_config_dir.ToString()))));
 		}
 
 		cache_dir = user_local_dir.ToString();
@@ -460,7 +467,6 @@ public:
 		return cache_dir;
 	}
 #endif
-
 };
 
 wxStandardPaths& Pcsx2AppTraits::GetStandardPaths()
@@ -1205,18 +1211,14 @@ void SysStatus( const wxString& text )
 // Applies a new active iso source file
 void SysUpdateIsoSrcFile( const wxString& newIsoFile )
 {
-	g_Conf->CurrentIso = fs::path(newIsoFile.ToStdWstring());
+	g_Conf->CurrentIso = Path::FromWxString(newIsoFile);
 	sMainFrame.UpdateStatusBar();
 	sMainFrame.UpdateCdvdSrcSelection();
 }
 
 void SysUpdateDiscSrcDrive( const wxString& newDiscDrive )
 {
-#if defined(_WIN32)
-	g_Conf->Folders.RunDisc = newDiscDrive.ToStdString();
-#else
-	g_Conf->Folders.RunDisc = newDiscDrive.ToStdString();
-#endif
+	g_Conf->Folders.RunDisc = Path::FromWxString(newDiscDrive);
 	AppSaveSettings();
 	sMainFrame.UpdateCdvdSrcSelection();
 }

--- a/pcsx2/gui/AppUserMode.cpp
+++ b/pcsx2/gui/AppUserMode.cpp
@@ -33,13 +33,12 @@ bool 					runWizard  = true; // This should default to true unless the stream sa
 
 std::vector<std::string> ErrorFolders;
 
-std::string data;
 std::string usermodePath;
 
 fs::path CustomDocumentsFolder;
 fs::path SettingsFolder;
 
-std::string InstallFolder;
+fs::path InstallFolder;
 fs::path PluginsFolder;
 
 YAML::Node stream;
@@ -62,10 +61,9 @@ const std::string PermissionFolders[] =
 // UserLocalData folder is the current working directory.
 InstallationModeType			InstallationMode;
 
-static fs::path GetPortableYamlPath()
+static fs::path GetPortableYamlFilePath()
 {
-	fs::path programDir = Path::GetExecutableDirectory() / "portable.yaml";
-	return programDir.make_preferred();
+	return Path::Combine(Path::GetExecutableDirectory(), "portable.yaml");
 }
 
 static wxString GetMsg_PortableModeRights()
@@ -73,7 +71,7 @@ static wxString GetMsg_PortableModeRights()
 	return pxE( L"Please ensure that these folders are created and that your user account is granted write permissions to them -- or re-run PCSX2 with elevated (administrator) rights, which should grant PCSX2 the ability to create the necessary folders itself.  If you do not have elevated rights on this computer, then you will need to switch to User Documents mode (click button below).");
 };
 
-bool Pcsx2App::TestUserPermissionsRights(const std::string& testFolder)
+bool Pcsx2App::TestUserPermissionsRights(const fs::path& testFolder)
 {
 
 	std::string createme, accessme;
@@ -137,8 +135,8 @@ bool Pcsx2App::TestForPortableInstall()
 {
 	InstallationMode = InstallMode_Portable;
 
-	fs::path portableYamlFile = GetPortableYamlPath();
-	std::string portableDocsFolder = portableYamlFile.parent_path();
+	fs::path portableYamlFile = GetPortableYamlFilePath();
+	fs::path portableDocsFolder = portableYamlFile.parent_path();
 
 	bool isPortable = Load(portableYamlFile);
 
@@ -169,11 +167,12 @@ bool Pcsx2App::TestForPortableInstall()
 		catch (const YAML::Exception& e)
 		{
 			// If the portable.yaml file gets into a bad state, we clear it and reset it
+			DevCon.Error("Invalid portable.yaml file, resetting... ");
 			runWizard = true;
 			stream = YAML::Node();
 			stream["RunWizard"] = runWizard;
 			// Save it immediately incase the Wizard is exited early, etc.
-			Save(GetPortableYamlPath());
+			Save(GetPortableYamlFilePath());
 		}
 
 		// Force-set the custom documents mode
@@ -190,7 +189,7 @@ bool Pcsx2App::TestForPortableInstall()
 		{
 			DoFirstTimeWizard();	
 			stream["RunWizard"] = false;	
-			Save(GetPortableYamlPath()); // Save Portable Yaml
+			Save(GetPortableYamlFilePath()); // Save Portable Yaml
 			
 			// Save user's new general settings
 			AppConfig_OnChangedSettingsFolder(true);
@@ -210,8 +209,7 @@ void Pcsx2App::WipeUserModeSettings()
 	if (InstallationMode == InstallMode_Portable)
 	{
 		// Remove the portable file entry "RunWizard" conforming to this instance of PCSX2.
-		std::string portableYamlFile(GetPortableYamlPath());
-		bool test = Load(portableYamlFile);
+		fs::path portableYamlFile(GetPortableYamlFilePath());
 		stream["RunWizard"] = true;
 		Save(portableYamlFile);
 	}
@@ -251,15 +249,11 @@ bool Pcsx2App::Load(fs::path fileName)
 			std::ifstream in = getFileAsInputStream(fileName);
 			stream = YAML::Load(in);
 			in.close();
-			std::ostringstream os;
-			os << stream;
-			data = os.str();
 			return true;
 		}
 		catch (const std::exception& e)
 		{
-			DevCon.Warning("ERROR: ", e.what());
-			data = "";
+			DevCon.Error("Could not load '%s'. Error: %s", fileName, e.what());
 			return false;
 		}
 	}
@@ -303,7 +297,7 @@ bool Pcsx2App::OpenInstallSettingsFile()
 	InstallationMode = InstallationModeType::InstallMode_Registered;
 	fs::path usrlocaldir = PathDefs::GetUserLocalDataDir();
 
-	InstallFolder = (wxFileName(wxStandardPaths::Get().GetExecutablePath())).GetPath().ToStdString();
+	InstallFolder = Path::FromWxString((wxFileName(wxStandardPaths::Get().GetExecutablePath())).GetPath());
 
 	std::string usermodeFile = (GetAppName().ToStdString() + "-reg.yaml");
 	usermodePath = Path::Combine(usrlocaldir, usermodeFile); 
@@ -317,7 +311,7 @@ bool Pcsx2App::OpenInstallSettingsFile()
 		stream["CustomDocumentsFolder"] = CustomDocumentsFolder.string();
 		stream["UseDefaultSettingsFolder"] = UseDefaultSettingsFolder;
 		stream["SettingsFolder"] = SettingsFolder.string();
-		stream["Install_Dir"] = InstallFolder;
+		stream["Install_Dir"] = InstallFolder.string();
 		stream["RunWizard"] = false;
 		Save(usermodePath);
 		DoFirstTimeWizard();

--- a/pcsx2/gui/Debugger/DisassemblyDialog.cpp
+++ b/pcsx2/gui/Debugger/DisassemblyDialog.cpp
@@ -58,7 +58,7 @@ DebuggerHelpDialog::DebuggerHelpDialog(wxWindow* parent)
 
 	auto fileName = Path::Combine(PathDefs::GetDocs(), "debugger.txt");
 
-	wxTextFile file(fileName);
+	wxTextFile file(Path::ToWxString(fileName));
 	wxString text(L"");
 
 	if (file.Open())

--- a/pcsx2/gui/Dialogs/FirstTimeWizard.cpp
+++ b/pcsx2/gui/Dialogs/FirstTimeWizard.cpp
@@ -72,9 +72,9 @@ Panels::FirstTimeIntroPanel::FirstTimeIntroPanel( wxWindow* parent )
 
 	FastFormatUnicode configFile, faqFile;
 #ifndef DOC_DIR_COMPILATION
-    wxString install = InstallFolder;
-    configFile.Write( L"file:///%s/Docs/Configuration_Guide.pdf", WX_STR(install) );
-	faqFile.Write( L"file:///%s/Docs/PCSX2_FAQ.pdf", WX_STR(install) );
+	wxString install = Path::ToWxString(InstallFolder);
+	configFile.Write(L"file:///%s/Docs/Configuration_Guide.pdf", WX_STR(install));
+	faqFile.Write(L"file:///%s/Docs/PCSX2_FAQ.pdf", WX_STR(install));
 #else
 	// Each linux distributions have his rules for path so we give them the possibility to
 	// change it with compilation flags. -- Gregory

--- a/pcsx2/gui/GlobalCommands.cpp
+++ b/pcsx2/gui/GlobalCommands.cpp
@@ -865,7 +865,7 @@ void AcceleratorDictionary::Map(const KeyAcceleratorCode& _acode, const char* se
 	KeyAcceleratorCode acode = _acode;
 	wxString overrideStr;
 	wxAcceleratorEntry codeParser; //Provides string parsing capabilities
-	wxFileConfig cfg(L"", L"", L"", GetUiKeysFilename().string(), wxCONFIG_USE_GLOBAL_FILE);
+	wxFileConfig cfg(L"", L"", L"", Path::ToWxString(GetUiKeysFilename()), wxCONFIG_USE_GLOBAL_FILE);
 	if (cfg.Read(wxString::FromUTF8(searchfor), &overrideStr))
 	{
 		// needs a '\t' prefix (originally used for wxMenu accelerators parsing)...

--- a/pcsx2/gui/MainMenuClicks.cpp
+++ b/pcsx2/gui/MainMenuClicks.cpp
@@ -371,7 +371,7 @@ bool MainEmuFrame::_DoSelectIsoBrowser(wxString& result)
 	if (ctrl.ShowModal() != wxID_CANCEL)
 	{
 		result = ctrl.GetPath();
-		g_Conf->Folders.RunIso = fs::path(result.ToStdWstring());
+		g_Conf->Folders.RunIso = Path::FromWxString(result);
 		return true;
 	}
 
@@ -387,8 +387,8 @@ bool MainEmuFrame::_DoSelectELFBrowser()
 
 	if (ctrl.ShowModal() != wxID_CANCEL)
 	{
-		g_Conf->Folders.RunELF = wxFileName(ctrl.GetPath()).GetPath().ToStdString();
-		g_Conf->CurrentELF = ctrl.GetPath().ToStdString();
+		g_Conf->Folders.RunELF = Path::FromWxString(wxFileName(ctrl.GetPath()).GetPath());
+		g_Conf->CurrentELF = Path::FromWxString(ctrl.GetPath());
 		return true;
 	}
 

--- a/pcsx2/gui/Panels/BiosSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/BiosSelectorPanel.cpp
@@ -132,7 +132,7 @@ void Panels::BiosSelectorPanel::Apply()
 			) );
 	}
 
-	g_Conf->BaseFilenames.Bios = fs::path((*m_BiosList)[(sptr)m_ComboBox->GetClientData(sel)].ToStdWstring());
+	g_Conf->BaseFilenames.Bios = Path::FromWxString((*m_BiosList)[(sptr)m_ComboBox->GetClientData(sel)]);
 }
 
 void Panels::BiosSelectorPanel::AppStatusEvent_OnSettingsApplied()

--- a/pcsx2/gui/Panels/DirPickerPanel.cpp
+++ b/pcsx2/gui/Panels/DirPickerPanel.cpp
@@ -259,7 +259,7 @@ void Panels::DirPickerPanel::AppStatusEvent_OnSettingsApplied()
 
 void Panels::DirPickerPanel::Apply()
 {
-	fs::path path( GetPath().ToString().ToStdWstring() );
+	fs::path path = Path::FromWxString(GetPath().ToString());
 
 	if (!Path::DoesExist(path))
 	{

--- a/pcsx2/gui/Panels/MemoryCardListPanel.cpp
+++ b/pcsx2/gui/Panels/MemoryCardListPanel.cpp
@@ -122,11 +122,11 @@ bool EnumerateMemoryCard(McdSlotItem& dest, const wxFileName& filename, const wx
 		return false;
 	}
 
-	dest.IsPresent		= true;
-	dest.Filename		= filename.GetFullPath().ToStdString();
-	if( filename.GetFullPath() == (basePath+filename.GetFullName()).GetFullPath() )
-		dest.Filename = filename.GetFullName().ToStdWstring();
-	
+	dest.IsPresent = true;
+	dest.Filename = Path::FromWxString(filename.GetFullPath());
+	if (filename.GetFullPath() == (basePath + filename.GetFullName()).GetFullPath())
+		dest.Filename = Path::FromWxString(filename.GetFullName());
+
 	return true;
 }
 
@@ -360,7 +360,7 @@ public:
 
 				if (dest.Slot>=0)
 				{//2 internal slots: swap
-					src.Filename  = tmpFilename.GetFullPath().ToStdString();
+					src.Filename  = Path::FromWxString(tmpFilename.GetFullPath());
 					src.IsPresent = tmpPresent;
 				}
 				else
@@ -574,7 +574,7 @@ void Panels::MemoryCardListPanel_Simple::AppStatusEvent_OnSettingsApplied()
 		m_Cards[slot].Filename = g_Conf->Mcd[slot].Filename;
 
 		// Automatically create the enabled but non-existing file such that it can be managed (else will get created anyway on boot)
-		wxString targetFile = Path::ToWxString(Path::Combine(fs::path(GetMcdPath().ToString().ToStdWstring()), m_Cards[slot].Filename.string()));
+		wxString targetFile = Path::ToWxString(Path::Combine(Path::FromWxString(GetMcdPath().ToString()), m_Cards[slot].Filename));
 		if (m_Cards[slot].IsEnabled && !(wxFileExists(targetFile) || wxDirExists(targetFile))) {
 			wxString errMsg;
 			if (isValidNewFilename(Path::ToWxString(m_Cards[slot].Filename), GetMcdPath(), errMsg, 5)) {
@@ -631,7 +631,7 @@ void Panels::MemoryCardListPanel_Simple::DoRefresh()
 		//	continue;
 
 		//wxFileName fullpath( m_FolderPicker->GetPath() + g_Conf->Mcd[slot].Filename.GetFullName() );
-		fs::path temp(m_FolderPicker->GetPath().ToString().ToStdWstring());
+		fs::path temp = Path::FromWxString(m_FolderPicker->GetPath().ToString());
 		wxFileName fullpath(Path::ToWxString(Path::Combine(temp, m_Cards[slot].Filename)));
 
 		EnumerateMemoryCard(m_Cards[slot], fullpath, m_FolderPicker->GetPath());
@@ -667,7 +667,7 @@ void Panels::MemoryCardListPanel_Simple::UiCreateNewCard(McdSlotItem& card)
 	if (result != wxID_CANCEL)
 	{
 		card.IsEnabled = true;
-		card.Filename  = dialog.result_createdMcdFilename.ToStdString();
+		card.Filename  = Path::FromWxString(dialog.result_createdMcdFilename);
 		card.IsPresent = true;
 		wxString toPrint = Path::ToWxString(card.Filename);
 		if (card.Slot >= 0) {
@@ -731,7 +731,7 @@ void Panels::MemoryCardListPanel_Simple::UiDeleteCard(McdSlotItem& card)
 	if (result)
 	{
 	
-		wxFileName fullpath(Path::ToWxString(Path::Combine(m_FolderPicker->GetPath().ToString().ToStdString(), card.Filename)));
+		wxFileName fullpath(Path::ToWxString(Path::Combine(Path::FromWxString(m_FolderPicker->GetPath().ToString()), card.Filename)));
 
 		card.IsEnabled = false;
 		Apply();
@@ -806,8 +806,8 @@ bool Panels::MemoryCardListPanel_Simple::UiDuplicateCard(McdSlotItem& src, McdSl
 			break;
 		}
 		
-		wxFileName srcfile(Path::ToWxString(Path::Combine(m_FolderPicker->GetPath().ToString().ToStdString(), src.Filename)));
-		wxFileName destfile(Path::ToWxString(Path::Combine(m_FolderPicker->GetPath().ToString().ToStdString(), dest.Filename)));
+		wxFileName srcfile(Path::ToWxString(Path::Combine(Path::FromWxString(m_FolderPicker->GetPath().ToString()), src.Filename)));
+		wxFileName destfile(Path::ToWxString(Path::Combine(Path::FromWxString(m_FolderPicker->GetPath().ToString()), dest.Filename)));
 		ScopedBusyCursor doh( Cursor_ReallyBusy );
 
 		if( !(    ( srcfile.FileExists() && wxCopyFile( srcfile.GetFullPath(), destfile.GetFullPath(), true ) )
@@ -879,7 +879,7 @@ void Panels::MemoryCardListPanel_Simple::UiRenameCard(McdSlotItem& card)
 	bool origEnabled = card.IsEnabled;
 	card.IsEnabled = false;
 	Apply();
-	if( !wxRenameFile( wxFileName(Path::ToWxString(Path::Combine(basepath.ToString().ToStdString(), card.Filename))).GetFullPath(), (basepath + wxFileName(newFilename)).GetFullPath(), false ) )
+	if( !wxRenameFile( wxFileName(Path::ToWxString(Path::Combine(Path::FromWxString(basepath.ToString()), card.Filename))).GetFullPath(), (basepath + wxFileName(newFilename)).GetFullPath(), false ) )
 	{
 		card.IsEnabled = origEnabled;
 		Apply();
@@ -888,7 +888,7 @@ void Panels::MemoryCardListPanel_Simple::UiRenameCard(McdSlotItem& card)
 		return;
 	}
 
-	card.Filename.wstring() = newFilename;
+	card.Filename = Path::FromWxString(newFilename);
 	card.IsEnabled=origEnabled;
 	Apply();
 
@@ -1121,10 +1121,10 @@ void Panels::MemoryCardListPanel_Simple::ReadFilesAtMcdFolder()
 	while (!m_allFilesystemCards.empty())
 		m_allFilesystemCards.pop_back();
 
-	m_filesystemPlaceholderCard.Slot=-1;
-	m_filesystemPlaceholderCard.IsEnabled=false;
-	m_filesystemPlaceholderCard.IsPresent=false;
-	m_filesystemPlaceholderCard.Filename.wstring()=L"";
+	m_filesystemPlaceholderCard.Slot = -1;
+	m_filesystemPlaceholderCard.IsEnabled = false;
+	m_filesystemPlaceholderCard.IsPresent = false;
+	m_filesystemPlaceholderCard.Filename = L"";
 
 
 	wxArrayString memcardList;

--- a/pcsx2/gui/Panels/MiscPanelStuff.cpp
+++ b/pcsx2/gui/Panels/MiscPanelStuff.cpp
@@ -76,7 +76,7 @@ DocsModeType Panels::DocsFolderPickerPanel::GetDocsMode() const
 void Panels::DocsFolderPickerPanel::Apply()
 {
 	DocsFolderMode			= (DocsModeType) m_radio_UserMode->GetSelection();
-	CustomDocumentsFolder	= m_dirpicker_custom->GetPath().ToString().ToStdString();
+	CustomDocumentsFolder	= Path::FromWxString(m_dirpicker_custom->GetPath().ToString());
 }
 
 void Panels::DocsFolderPickerPanel::AppStatusEvent_OnSettingsApplied()

--- a/pcsx2/gui/Panels/PluginSelectorPanel.cpp
+++ b/pcsx2/gui/Panels/PluginSelectorPanel.cpp
@@ -566,7 +566,7 @@ bool Panels::PluginSelectorPanel::ValidateEnumerationStatus()
 	// occurs during file enumeration.
 	std::unique_ptr<std::vector<fs::path>> pluginlist(new std::vector<fs::path>());
 
-	int pluggers = EnumeratePluginsInFolder(m_ComponentBoxes->GetPluginsPath().ToString().ToStdWstring(), pluginlist.get());
+	int pluggers = EnumeratePluginsInFolder(Path::FromWxString(m_ComponentBoxes->GetPluginsPath().ToString()), pluginlist.get());
 
 	if( !m_FileList || (*pluginlist != *m_FileList) )
 		validated = false;

--- a/pcsx2/gui/RecentIsoList.cpp
+++ b/pcsx2/gui/RecentIsoList.cpp
@@ -190,7 +190,7 @@ void RecentIsoManager::InsertIntoMenu( int id )
 	if (this->m_firstIdForMenuItems_or_wxID_ANY != wxID_ANY)
 		wxid = this->m_firstIdForMenuItems_or_wxID_ANY + id;
 
-	wxString filename = Path::GetFilename(curitem.Filename.ToStdString());
+	wxString filename = Path::GetFilename(Path::FromWxString(curitem.Filename));
 	// & is used to specify the keyboard shortcut key in menu labels. && must
 	// be used to display an &.
 	filename.Replace("&", "&&", true);

--- a/pcsx2/ps2/BiosTools.cpp
+++ b/pcsx2/ps2/BiosTools.cpp
@@ -201,13 +201,13 @@ static void LoadExtraRom( const wxChar* ext, u8 (&dest)[_size] )
 
 	try
 	{
-		if( (filesize=Path::GetFileSize( Bios1.ToStdString() ) ) <= 0 )
+		if ((filesize = Path::GetFileSize(Path::FromWxString(Bios1))) <= 0)
 		{
 			// Try the name properly extensioned next (name.rom1)
-			Bios1 = Path::ReplaceExtension( Bios, ext );
-			if( (filesize=Path::GetFileSize( Bios1.ToStdString() ) ) <= 0 )
+			Bios1 = Path::ReplaceExtension(Bios, ext);
+			if ((filesize = Path::GetFileSize(Path::FromWxString(Bios1))) <= 0)
 			{
-				Console.WriteLn( Color_Gray, L"BIOS %s module not found, skipping...", ext );
+				Console.WriteLn(Color_Gray, L"BIOS %s module not found, skipping...", ext);
 				return;
 			}
 		}
@@ -236,7 +236,8 @@ static void LoadIrx( const wxString& filename, u8* dest )
 	try
 	{
 		wxFile irx(filename);
-		if( (filesize=Path::GetFileSize( filename.ToStdString() ) ) <= 0 ) {
+		if ((filesize = Path::GetFileSize(Path::FromWxString(filename))) <= 0)
+		{
 			Console.Warning(L"IRX Warning: %s could not be read", WX_STR(filename));
 			return;
 		}

--- a/pcsx2/x86/iR3000A.cpp
+++ b/pcsx2/x86/iR3000A.cpp
@@ -231,7 +231,7 @@ static void iIopDumpBlock( int startpc, u8 * ptr )
 	Console.WriteLn( "dump1 %x:%x, %x", startpc, psxpc, psxRegs.cycle );
 	Path::CreateFolder(g_Conf->Folders.Logs);
 
-	wxString filename( Path::Combine( g_Conf->Folders.Logs, wxsFormat( L"psxdump%.8X.txt", startpc ).ToStdString() ) );
+	wxString filename = Path::ToWxString(Path::Combine(g_Conf->Folders.Logs, Path::FromWxString(wxsFormat(L"psxdump%.8X.txt", startpc))));
 	AsciiFile f( filename, L"w" );
 
 	f.Printf("Dump PSX register data: 0x%x\n\n", (uptr)&psxRegs);

--- a/pcsx2/x86/microVU_Log.inl
+++ b/pcsx2/x86/microVU_Log.inl
@@ -48,7 +48,7 @@ void __mVUdumpProgram(microVU& mVU, microProgram& prog) {
 	mVUbranch	= 0;
 
 	const wxString logname(wxsFormat(L"microVU%d prog - %02d.html", mVU.index, prog.idx));
-	mVU.logFile = std::unique_ptr<AsciiFile>(new AsciiFile(Path::Combine(g_Conf->Folders.Logs, logname.ToStdString()), L"w"));
+	mVU.logFile = std::unique_ptr<AsciiFile>(new AsciiFile(Path::ToWxString(Path::Combine(g_Conf->Folders.Logs, Path::FromWxString(logname))), L"w"));
 
 	mVUlog("<html>\n");
 	mVUlog("<title>microVU%d MicroProgram Log</title>\n", mVU.index);


### PR DESCRIPTION
From my conversation with Tellow:

> Hey, I'm doing a full pass of beards PR and was going to fix issues as I went along, wanted to confirm something.  So:
> - for fs::path ---> wxString = ToWxString() (just calls StdString or StdWstring)
> - for std::string ---> wxString = wxStrFromUTF8()
> - but what is the correct conversion for wxString or std::string ---> fs::path?  Is the implicit conversion good enough?  ie. fs::path(STR_VAR_HERE)

> fs::path ↔︎ std::string can just use constructors
wxString → fs::path fs::path(wxString.wx_str()) should work, though you can make a separate function for it if you want

This is a full pass through all of the immediate modifications made.  Other than possible transitives (though id expect compiler errors since they used to be `wxDir` right?) I'm pretty confident in saying we've caught everything that could be a unicode problem.

Even in places, like linux code, where `std::string` is fine, I refactored everything to use the same `Path` functions to keep things consistent.

Needs testing around:
 - General regression testing, did i re-break something?
 - Did this fix the user config file problem, i changed code that seemed not-unicode safe around it, so im hoping it does?
 - The stuff i marked on the parent PR in my latest review https://github.com/PCSX2/pcsx2/pull/4005#pullrequestreview-572984376

This should likely be rebased after it's merged, since its a huge commit.